### PR TITLE
build: specify project is a public release

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,5 +87,8 @@
     "typescript": {
       "optional": true
     }
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/Kenneth-Sills/eslint-config-airbnb-typescript.git"
+    "url": "git+https://github.com/Kenneth-Sills/eslint-config-airbnb-typescript.git"
   },
   "license": "MIT",
   "author": "Kenneth Sills <ksills.dev@gmail.com>",


### PR DESCRIPTION
The [initial release](https://github.com/Kenneth-Sills/eslint-config-airbnb-typescript/pull/16) failed because semantic release was allowing it to default to a private publication, which is only allowed for paid accounts.

See [job 29333391792 for failure log](https://github.com/Kenneth-Sills/eslint-config-airbnb-typescript/actions/runs/10585850502/job/29333391792#step:6:349).